### PR TITLE
Add search support to extensions model

### DIFF
--- a/controllers/components/ApiComponent.php
+++ b/controllers/components/ApiComponent.php
@@ -86,6 +86,7 @@ class Slicerpackages_ApiComponent extends AppComponent
    * @param slicer_revision (Optional) The slicer revision the package was built against
    * @param release (Optional) Release identifier associated with a package.
    If not set, it will return both released and non-released packages.
+   * @param search (Optional) Text matched against extension name or description.
    * @param order (Optional) What parameter to order results by (revision | packagetype | submissiontype | arch | os)
    * @param direction (Optional) What direction to order results by (asc | desc).  Default asc
    * @param limit (Optional) Limit result count. Must be a positive integer.

--- a/models/pdo/ExtensionModel.php
+++ b/models/pdo/ExtensionModel.php
@@ -29,11 +29,19 @@ class Slicerpackages_ExtensionModel extends Slicerpackages_ExtensionModelBase
                                'submissiontype' => 'any', 'packagetype' => 'any',
                                'slicer_revision' => 'any', 'revision' => 'any',
                                'productname' => 'any', 'codebase' => 'any',
-                               'release' => 'any', 'category' => 'any'))
+                               'release' => 'any', 'category' => 'any', 'search' => ''))
     {
     $sql = $this->database->select();
     $sqlCount = $this->database->select()
                      ->from(array($this->_name), array('count' => 'count(*)'));
+    if(array_key_exists('search', $params) && $params['search'] != '')
+      {
+      $filterClause = "slicerpackages_extension.productname LIKE ?"
+                  ." OR slicerpackages_extension.description LIKE ?";
+      $pattern = '%'.$params['search'].'%';
+      $sql->where($filterClause, $pattern);
+      $sqlCount->where($filterClause, $pattern);
+      }
     foreach(array('extension_id', 'os', 'arch', 'submissiontype', 'packagetype', 'revision', 'slicer_revision', 'productname', 'codebase', 'release', 'category') as $option)
       {
       if(array_key_exists($option, $params) && $params[$option] != 'any')
@@ -123,7 +131,15 @@ class Slicerpackages_ExtensionModel extends Slicerpackages_ExtensionModelBase
                 ->from('slicerpackages_extension', array('category' => 'category', 'count' => 'count(*)'));
     foreach($params as $key => $value)
       {
-      $sql->where($key.' = ?', $value);
+      if($key == 'search')
+        {
+        $filterClause = "productname LIKE ? OR description LIKE ?";
+        $sql->where($filterClause, '%'.$value.'%');
+        }
+      else
+        {
+        $sql->where($key.' = ?', $value);
+        }
       }
     $sql->where('category != ?', '');
     $sql->group('category');


### PR DESCRIPTION
Add search support to the slicerpackages model, using a new parameter 'search' which allows limiting results to those whose name or description contains the specified text.

This affects ONLY the model. The slicerappstore module also requires changes in order to take advantage of this functionality, but the model support is required first.
