### PR TITLE
Add icon URL to API results

### DIFF
--- a/controllers/components/ApiComponent.php
+++ b/controllers/components/ApiComponent.php
@@ -127,6 +127,7 @@ class Slicerpackages_ApiComponent extends AppComponent
                          'productname' => $dao->getProductname(),
                          'category' => $dao->getCategory(),
                          'description' => $dao->getDescription(),
+                         'icon_url' => $dao->getIconUrl(),
                          'screenshots' => $dao->getScreenshots(),
                          'contributors' => $dao->getContributors(),
                          'homepage' => $dao->getHomepage(),


### PR DESCRIPTION
Change midas.slicerpackages.extension.list API to also include the icon URL in the result metadata. We want this so that Slicer can use icons for installed extensions. (It's not entirely decided if Slicer will download the icons itself, or if we'll start packaging the icons in the built extension packages, but either way this provides a neat solution to Slicer needing to know the name - or at least the file extension - of the icon.)
