### PR TITLE
Disable category filter in some situations

### DIFF
--- a/models/pdo/ExtensionModel.php
+++ b/models/pdo/ExtensionModel.php
@@ -74,7 +74,8 @@ class Slicerpackages_ExtensionModel extends Slicerpackages_ExtensionModelBase
           }
         }
       }
-    if(!array_key_exists('category', $params) || $params['category'] == 'any')
+    if(!(array_key_exists('category', $params) && $params['category'] != 'any') &&
+       !(array_key_exists('extension_id', $params) || array_key_exists('productname', $params)))
       {
       foreach(self::$excludeCategories as $exclude)
         {


### PR DESCRIPTION
Don't apply implicit category filtering when asking about a specific extension (either by ID, or by name), as it doesn't make much sense to do so in these cases (and more importantly, breaks installing of said extensions because the metadata lookup fails).
